### PR TITLE
pluralize "Exceptions" category in cabal file

### DIFF
--- a/throwable-exceptions.cabal
+++ b/throwable-exceptions.cabal
@@ -8,7 +8,7 @@ license-file:        LICENSE
 author:              aiya000
 maintainer:          aiya000.develop@gmail.com
 copyright:           aiya000
-category:            Exception
+category:            Exceptions
 build-type:          Simple
 cabal-version:       >=1.10
 extra-source-files:  README.md


### PR DESCRIPTION
Hi, I was wondering if it might be possible to try to clean up some of the package categories on Hackage. For example, there is one category called ["Exception"](https://hackage.haskell.org/packages/#cat:Exception), and another called "Exceptions". The latter category is larger, so I was hoping you might be willing to release this change to move your package into that category. Thank you, sorry to bother :)